### PR TITLE
Add Zcheme (and assoicated projects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
   - [tres🗒️ValueTree-based JSON parser ](https://github.com/ziglibs/tres)
   - [zacho🗒️Zig's Mach-O parser](https://github.com/kubkon/zacho)
   - [zelf🗒️Zig's ELF parser utility](https://github.com/kubkon/zelf)
+  - [zexpr🗒️Zig S-expression library](https://hg.sr.ht/~hutzdog/Zcheme/browse/zexpr?rev=tip)
   - [zig-clap🗒️Simple command line argument parsing library ](https://github.com/Hejsil/zig-clap)
   - [zig-cli🗒️A simple package for building command line apps in Zig](https://github.com/sam701/zig-cli)
   - [zigmkv🗒️wip Matroska/webm (mkv) parser in Zig ](https://github.com/vi/zigmkv)

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@
     - [zig-string🗒️A String Library made in Zig ](https://github.com/JakubSzark/zig-string)
     - [zigtimsort🗒️TimSort implementation for Zig ](https://github.com/marijnfs/zigtimsort)
     - [ziter🗒️Best iterator library for Zig (fight me!)](https://github.com/Hejsil/ziter)
+    - [znum🗒️Simple numeric tower implemented on Zig standard types](https://hg.sr.ht/~hutzdog/Zcheme/browse/znum?rev=tip)
     - [zort🗒️Implementation of 9 sorting algorithms in Zig ](https://github.com/AliChraghi/zort)
     - [zzz🗒️Simple and boring human readable data format for Zig. ](https://github.com/gruebite/zzz)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
   - [rotate-zig🗒️a programming language written in zig ](https://github.com/Airbus5717/rotate-zig)
   - [tres🗒️ValueTree-based JSON parser ](https://github.com/ziglibs/tres)
   - [zacho🗒️Zig's Mach-O parser](https://github.com/kubkon/zacho)
+  - [zcheme🗒️WIP implementation of R7RS Scheme](https://hg.sr.ht/~hutzdog/Zcheme)
   - [zelf🗒️Zig's ELF parser utility](https://github.com/kubkon/zelf)
   - [zexpr🗒️Zig S-expression library](https://hg.sr.ht/~hutzdog/Zcheme/browse/zexpr?rev=tip)
   - [zig-clap🗒️Simple command line argument parsing library ](https://github.com/Hejsil/zig-clap)


### PR DESCRIPTION
This PR adds in a few packages of mine which have been in development for the past few months. They are grouped here, as they share a repository and are mostly components needed to implement the main package Zcheme (which aims to implement R7RS Scheme, though currently it is little more than a slightly broken RPN 4-function calculator). That said, I've separated out the commits so that the individual packages can be cherry picked when merging (this just saves a lot of time for everyone involved). If it is too early in development to merge in, that is understandable (I'm mostly hoping to get it on the map due to equal parts pride, need for assistance, and status as a non-trivial project which has already hit critical mass for usefulness to the development of Zig [in both potential as compiler development data and as a somewhat useful set of libraries for the early ecosystem]).