### PR TITLE
added sliding-puzzle-in-zig to the 'Game & Desktop(GUI) Applications' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@
   [pixelcode](https://github.com/pfgithub/pixelcode) 
   - ![Star](https://img.shields.io/github/stars/mkeeter/rayray?color=orange)
   [rayray🗒️A tiny GPU raytracer, using Zig and WebGPU](https://github.com/mkeeter/rayray) 
+  - ![Star](https://img.shields.io/github/stars/10aded/sliding-puzzle-in-zig?color=orange)
+  [sliding-puzzle-in-zig🗒️A sliding tile puzzle game made with zglfw and zopengl](https://github.com/10aded/sliding-puzzle-in-zig)
   - ![Star](https://img.shields.io/github/stars/fabioarnold/snake-zig?color=orange)
   [snake-zig🗒️A simple snake game written in the Zig programming language using OpenGL 2](https://github.com/fabioarnold/snake-zig) 
   - ![Star](https://img.shields.io/github/stars/MasterQ32/SoftRenderLib?color=orange)


### PR DESCRIPTION
Browsing the current list of Game & Desktop(GUI) Applications, I didn't see a project that uses the `zig-gamedev` libraries `zglfw` or `zopengl`. My project, however, does use these!

When I started exploring `zglfw` and `zopengl` I wanted a example which used the libraries to do something more complicated than launch a blank window to reference, but I couldn't find any!

The addition of my project to Awesome-Zig will hopefully help anyone else curious about the libraries, as well as anyone who likes sliding puzzle games and wants one made in Zig.