### PR TITLE
Link for cova project now points to the actual cova repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@
   - ![Star](https://img.shields.io/github/stars/ziglibs/ansi-term?color=orange)
   [ansi-term🗒️Zig library for dealing with ANSI terminals](https://github.com/ziglibs/ansi-term)
   - ![Star](https://img.shields.io/github/stars/00jciv00/cova?color=orange)
-   [cova🗒️Commands, Options, Values, Arguments. A simple yet robust cross-platform command line argument parsing library for Zig.](https://github.com/ziglibs/ansi-term)
+   [cova🗒️Commands, Options, Values, Arguments. A simple yet robust cross-platform command line argument parsing library for Zig.](https://github.com/00JCIV00/cova)
   - ![Star](https://img.shields.io/github/stars/jayschwa/dos.zig?color=orange)
   [dos.zig🗒️Create DOS programs with Zig](https://github.com/jayschwa/dos.zig) 
   - ![Star](https://img.shields.io/github/stars/ziglibs/known-folders?color=orange)


### PR DESCRIPTION
Replaced the old duplicate link for ansi-term and added the correct repo link for the cova project.
Closes #82 