### PR TITLE
Add boj-server to Other Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,10 +465,10 @@
   [zwld🗒️Experimental wasm linker](https://github.com/Luukdegram/zwld) 
 
 - ### Other Applications
-  - ![Star](https://img.shields.io/github/stars/oven-sh/bun?color=orange)
-  [bun🗒️Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one](https://github.com/oven-sh/bun) 
   - ![Star](https://img.shields.io/github/stars/hyperpolymath/boj-server?color=orange)
   [boj-server🗒️Federated developer tool catalogue with 18 capability cartridges. Zig handles the FFI layer (C-ABI exports, thread-safe mutexes, shared library compilation). Paired with Idris2 for formal verification and V-lang for network adapters. 307 tests, zero runtime dependencies.](https://github.com/hyperpolymath/boj-server)
+  - ![Star](https://img.shields.io/github/stars/oven-sh/bun?color=orange)
+  [bun🗒️Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one](https://github.com/oven-sh/bun) 
   - ![Star](https://img.shields.io/github/stars/Luukdegram/cld?color=orange)
   [cld🗒️Linker for the Coff/PE file format](https://github.com/Luukdegram/cld) 
   - ![Star](https://img.shields.io/github/stars/ziglibs/computils?color=orange)

--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@
 - ### Other Applications
   - ![Star](https://img.shields.io/github/stars/oven-sh/bun?color=orange)
   [bun🗒️Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one](https://github.com/oven-sh/bun) 
+  - ![Star](https://img.shields.io/github/stars/hyperpolymath/boj-server?color=orange)
+  [boj-server🗒️Federated developer tool catalogue with 18 capability cartridges. Zig handles the FFI layer (C-ABI exports, thread-safe mutexes, shared library compilation). Paired with Idris2 for formal verification and V-lang for network adapters. 307 tests, zero runtime dependencies.](https://github.com/hyperpolymath/boj-server)
   - ![Star](https://img.shields.io/github/stars/Luukdegram/cld?color=orange)
   [cld🗒️Linker for the Coff/PE file format](https://github.com/Luukdegram/cld) 
   - ![Star](https://img.shields.io/github/stars/ziglibs/computils?color=orange)


### PR DESCRIPTION
## Add boj-server

Adds [boj-server](https://github.com/hyperpolymath/boj-server) to the Other Applications section.

**Zig usage:** BoJ Server uses Zig for the entire FFI layer — C-ABI exports, thread-safe mutexes (`std.Thread.Mutex`) on all 9 FFI modules, shared library compilation (18 `.so` cartridges). Zero runtime dependencies. 307 tests passing.

The Zig FFI layer bridges Idris2 formal proofs (ABI definitions) to V-lang network adapters (REST + gRPC + GraphQL).

- **License:** PMPL-1.0-or-later
- Community project, open to contributors