### PR TITLE
docs: add ziex project to README (trim trailing whitespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@
   [zelda🗒️A simple HTTP client library for Zig](https://github.com/haze/zelda) 
   - ![Star](https://img.shields.io/github/stars/floscodes/zerve?color=orange)
   [zerve🗒️Simple framework for writing web services and web apps in zig](https://github.com/floscodes/zerve) 
+  - ![Star](https://img.shields.io/github/stars/ziex-dev/ziex?color=orange)
+  [ziex🗒️A full-stack web framework for Zig](https://github.com/ziex-dev/ziex) 
   - ![Star](https://img.shields.io/github/stars/haze/zig-libressl?color=orange)
   [zig-libressl🗒️LibreSSL stream wrappers for Zig](https://github.com/haze/zig-libressl)
   - ![Star](https://img.shields.io/github/stars/kubkon/zig-objdump?color=orange)

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@
   - ![Star](https://img.shields.io/github/stars/floscodes/zerve?color=orange)
   [zerve🗒️Simple framework for writing web services and web apps in zig](https://github.com/floscodes/zerve) 
   - ![Star](https://img.shields.io/github/stars/ziex-dev/ziex?color=orange)
-  [ziex🗒️A full-stack web framework for Zig](https://github.com/ziex-dev/ziex) 
+  [ziex🗒️A full-stack web framework for Zig](https://github.com/ziex-dev/ziex)
   - ![Star](https://img.shields.io/github/stars/haze/zig-libressl?color=orange)
   [zig-libressl🗒️LibreSSL stream wrappers for Zig](https://github.com/haze/zig-libressl)
   - ![Star](https://img.shields.io/github/stars/kubkon/zig-objdump?color=orange)


### PR DESCRIPTION
This mirrors the docs/add-ziex contribution from #93 while removing the trailing whitespace flagged by Copilot review.

- adds ziex in the framework section
- keeps alphabetical placement
- trims the trailing space on the added project line

Supersedes #93 if maintainers prefer to merge from a writable branch.